### PR TITLE
don't panic on unknown flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,9 @@ import (
 func main() {
 	var l *slog.Logger
 	handleError := func(err error) {
-		l.Error(err.Error())
+		if l != nil {
+			l.Error(err.Error())
+		}
 
 		var e cli.ExitCoder
 		if errors.As(err, &e) {


### PR DESCRIPTION
I tried to output using logger but seems that urfave/cli does not allow unknown args so `before` cannot be invoked resulting no logger initialization.